### PR TITLE
#21 詳細ページ全体コンポーネントを作成

### DIFF
--- a/pages/detail.jsx
+++ b/pages/detail.jsx
@@ -1,0 +1,23 @@
+import { Box, Flex, Heading, Spacer } from '@chakra-ui/layout'
+import React from 'react'
+import DetailCard from './DetailCard'
+
+export default function detail() {
+  return (
+    <>
+      This is header
+      <Box width="1080px" mx="auto">
+        <Flex align="center" mb="16px">
+          <Heading fontSize="3xl">SHOW TODO</Heading>
+          <Spacer />
+          <Flex>ボタンたち</Flex>
+        </Flex>
+        <Flex>
+          <DetailCard />
+          <Spacer />
+          <Box>コメントたちが並びます</Box>
+        </Flex>
+      </Box>
+    </>
+  )
+}

--- a/pages/detail.jsx
+++ b/pages/detail.jsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, Spacer } from '@chakra-ui/layout'
+import { Box, Container, Flex, Heading, Spacer } from '@chakra-ui/layout'
 import React from 'react'
 import DetailCard from './DetailCard'
 
@@ -6,7 +6,7 @@ export default function detail() {
   return (
     <>
       This is header
-      <Box width="1080px" mx="auto">
+      <Container maxW="container.lg" mx="auto">
         <Flex align="center" mb="16px">
           <Heading fontSize="3xl">SHOW TODO</Heading>
           <Spacer />
@@ -17,7 +17,7 @@ export default function detail() {
           <Spacer />
           <Box>コメントたちが並びます</Box>
         </Flex>
-      </Box>
+      </Container>
     </>
   )
 }


### PR DESCRIPTION
## 対応内容・対応背景・妥協点
詳細ページの全体コンポーネントを作成

## やったこと
<img width="1136" alt="スクリーンショット 2022-01-16 18 51 14" src="https://user-images.githubusercontent.com/88525743/149674616-7330292d-9a1f-4058-bf1c-390e6af47aec.png">

1. 詳細ページ内、各コンポーネントの親を作成（/pages/detail.jsx）
2. 画像の薄青部分を横幅1080pxに指定
3. どこまで作成するか分からなかったのと親要素だけではレビューしにくいと思い、画像のように #22  のSHOW TODOを入れました（タイトルの「SHOW TODO」はこのブランチで対応済）
4. 3の理由からheader、ボタン、コメントをそれぞれ配置

## やってないこと・できていないこと

> - 画像の薄青部分を横幅1080pxに指定

=レスポンシブは未実装

分かりにくければご指摘いただけると嬉しいです、よろしくお願いいたします。

close #21 