### PR TITLE
#66 TodoList一覧ページの組み込みとレイアウト調整、ボタン作成

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,14 +1,14 @@
 import '../styles/globals.scss'
 import { ChakraProvider } from '@chakra-ui/react'
-import { RecoilRoot } from 'recoil'
+// import { RecoilRoot } from 'recoil'
 
 function MyApp({ Component, pageProps }) {
   return (
-    <RecoilRoot>
-      <ChakraProvider>
-        <Component {...pageProps} />
-      </ChakraProvider>
-    </RecoilRoot>
+    // <RecoilRoot>
+    <ChakraProvider>
+      <Component {...pageProps} />
+    </ChakraProvider>
+    // </RecoilRoot>
   )
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,7 @@ export default function Home() {
   return (
     <>
       <Header />
-      <Container maxW="container.lg">
+      <Container maxW="container.xl">
         <Heading as="h2" size="lg" my={2}>
           TODO LIST
         </Heading>
@@ -29,7 +29,7 @@ export default function Home() {
             <ResetButton />
           </HStack>
           <Spacer />
-          <Box w="15%">
+          <Box w="150px">
             <MainButtons />
           </Box>
         </Flex>

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,7 @@ import SearchForm from '../src/components/atoms/search/SearchForm'
 import SearchStatus from '../src/components/atoms/search/SearchStatus'
 import { SearchPriority } from '../src/components/atoms/search/SearchPriority'
 import TodoTable from '../src/components/organisms/Todo/TodoTable'
+import { ResetButton } from '../src/components/atoms/button/ResetButton'
 
 export default function Home() {
   return (
@@ -15,7 +16,7 @@ export default function Home() {
           TODO LIST
         </Heading>
         <Flex mb={8}>
-          <HStack spacing="24px">
+          <HStack spacing="24px" align="flex-end">
             <Box>
               <SearchForm />
             </Box>
@@ -25,6 +26,7 @@ export default function Home() {
             <Box>
               <SearchPriority />
             </Box>
+            <ResetButton />
           </HStack>
           <Spacer />
           <Box w="15%">

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,37 @@
-import { Heading } from '@chakra-ui/react'
-import { Container } from '@chakra-ui/react'
+import { Box, Container, Flex, Heading, HStack, Spacer } from '@chakra-ui/react'
+import MainButtons from '../src/components/molecules/MainButtons'
+import Header from '../src/components/organisms/Header/Header'
+import SearchForm from '../src/components/atoms/search/SearchForm'
+import SearchStatus from '../src/components/atoms/search/SearchStatus'
+import { SearchPriority } from '../src/components/atoms/search/SearchPriority'
+import TodoTable from '../src/components/organisms/Todo/TodoTable'
 
 export default function Home() {
   return (
     <>
-      <Container maxW='container.lg'>
+      <Header />
+      <Container maxW="container.lg">
         <Heading as="h2" size="lg" my={2}>
           TODO LIST
         </Heading>
+        <Flex mb={8}>
+          <HStack spacing="24px">
+            <Box>
+              <SearchForm />
+            </Box>
+            <Box>
+              <SearchStatus />
+            </Box>
+            <Box>
+              <SearchPriority />
+            </Box>
+          </HStack>
+          <Spacer />
+          <Box w="15%">
+            <MainButtons />
+          </Box>
+        </Flex>
+        <TodoTable />
       </Container>
     </>
   )

--- a/src/components/atoms/button/ResetButton.jsx
+++ b/src/components/atoms/button/ResetButton.jsx
@@ -1,0 +1,19 @@
+import { Button } from '@chakra-ui/button'
+import React from 'react'
+
+export const ResetButton = () => {
+  return (
+    <Button
+      backgroundColor="gray.500"
+      borderRadius="50px"
+      border="1px solid"
+      borderColor="rgba(0, 0, 0, 0.8)"
+      w="104px"
+      h="40px"
+      variant="solid"
+      _hover={{ backgroundColor: 'gray.600' }}
+    >
+      RESET
+    </Button>
+  )
+}

--- a/src/components/organisms/Header/Header.jsx
+++ b/src/components/organisms/Header/Header.jsx
@@ -3,7 +3,7 @@ import { Box, Container, Flex, Heading, Spacer, Text } from '@chakra-ui/layout'
 const Header = () => {
   return (
     <Box bg={'green.300'}>
-      <Container maxW="container.lg">
+      <Container maxW="container.xl">
         <Flex py="12px" alignItems="center">
           <Heading fontSize="5xl">TODO</Heading>
           <Spacer />

--- a/src/components/organisms/Todo/TodoTable.jsx
+++ b/src/components/organisms/Todo/TodoTable.jsx
@@ -1,4 +1,5 @@
 import { Table, Tbody, Thead, Th, Tr, Td } from '@chakra-ui/react'
+import TodoListChild from '../../atoms/TodoListChild'
 
 export default function TodosTable() {
   return (
@@ -13,32 +14,8 @@ export default function TodosTable() {
           <Th>Action</Th>
         </Tr>
       </Thead>
-      <Tbody>
-        <Tr>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-        </Tr>
-        <Tr>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-        </Tr>
-        <Tr>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-          <Td>Test</Td>
-        </Tr>
-      </Tbody>
+
+      <TodoListChild />
     </Table>
   )
 }


### PR DESCRIPTION
close #66 

## 対応内容・対応背景・妥協点
一覧ページの各コンポーネントの組み込み、余白などのレイアウト調整、リセットボタン作成

## やったこと
<img width="1165" alt="Screenshot 2022-01-23 at 23 06 09" src="https://user-images.githubusercontent.com/88525743/150701732-51630904-6580-4c27-ba9f-0a95c8722c69.png">

- 各コンポーネントをインポートして組み込み
- 余白調整
- ResetButton.jsxを作成し配置
- `src/components/organisms/Todo/TodoTable.jsx `に`<TodoListChild />`をインポート


## やってないこと・できていないこと

- ページネーションは保留（機能での実装）のため未着手
- Containerの大きさの調整（現在崩れています。他ページの大きさと合わせるなら後で調整したほうがいいかなと思いましたが、どうでしょう、、）

- （一時的に`_app.jsn`のrecoil部分コメントアウトしています）

ご確認よろしくお願いいたします。
