### PR TITLE
#93 todoをリスト一覧に表示

### DIFF
--- a/src/components/atoms/TodoListChild.jsx
+++ b/src/components/atoms/TodoListChild.jsx
@@ -1,37 +1,39 @@
-import React from 'react';
-import {
-  Tbody,
-  Tr,
-  Td,
-  Button,
-  Select
-} from '@chakra-ui/react'
+import React from 'react'
+import { Tbody, Tr, Td, Button, Select } from '@chakra-ui/react'
 import { EditIcon, DeleteIcon } from '@chakra-ui/icons'
-
-
+import { useRecoilState } from 'recoil'
+import { todoState } from '../../hooks/TodoState'
 
 const TodoListChild = () => {
+  // TodoState.jsで定義したtodos,setTodosを呼び出し
+  const [todos, setTodos] = useRecoilState(todoState)
   return (
     <Tbody>
-      <Tr>
-        <Td fontSize='16px' fontWeight="bold">Github上に静的サイトをホスティングする</Td>
-        <Td>
-        <Button rounded="full" bg="green.50" size="lg" fontSize='12px'>NOT STARTED</Button>
-        </Td>
-        <Td>
-          <Select borderColor="tomato" fontSize='16px'>
-            <option>High</option>
-            <option>Middle</option>
-            <option>Low</option>
-          </Select>
-        </Td>
-        <Td fontSize='14px'>2020-11-8 18:55</Td>
-        <Td fontSize='14px'>2020-11-8 18:55</Td>
-        <Td>
-        <EditIcon w={18} h={18} me={5} />
-        <DeleteIcon w={18} h={18}/>
-        </Td>
-      </Tr>
+      {todos.map((todo) => (
+        <Tr key={todo.id}>
+          <Td fontSize="16px" fontWeight="bold">
+            {todo.title}
+          </Td>
+          <Td>
+            <Button rounded="full" bg="green.50" size="lg" fontSize="12px">
+              {todo.status}
+            </Button>
+          </Td>
+          <Td>
+            <Select borderColor="tomato" fontSize="16px">
+              <option>High</option>
+              <option>Middle</option>
+              <option>Low</option>
+            </Select>
+          </Td>
+          <Td fontSize="14px">{todo.created_day}</Td>
+          <Td fontSize="14px">2020-11-8 18:55</Td>
+          <Td>
+            <EditIcon w={18} h={18} me={5} />
+            <DeleteIcon w={18} h={18} />
+          </Td>
+        </Tr>
+      ))}
     </Tbody>
   )
 }


### PR DESCRIPTION
close #93 

## 対応内容・対応背景・妥協点

/Newtodo/で新規作成したtodoを一覧ページに反映する。

<img width="1386" alt="Screenshot 2022-02-03 at 23 26 30" src="https://user-images.githubusercontent.com/88525743/152446192-997d34aa-7894-4e1d-ba0c-f9702baa143b.png">

## やったこと

- #68 で作成いただいたrecoilを利用
- map関数で一覧を表示

## やってないこと・できていないこと

- 取得したStatusの種類に応じてボタンのデザイン変更は別issueのため（自分担当です）やっておりません…
- PRIORITYについても同様です
- UPDATEは別issueがないように見受けられましたがやっておりません。。

## テスト
テストを何個か入れてしまいました（画像参照）

ご指摘よろしくお願いいたします。
