### PR TITLE
#72 todoのタイトル、詳細、CreatedをShow Todoに表示

### DIFF
--- a/pages/ShowTodo.jsx
+++ b/pages/ShowTodo.jsx
@@ -8,6 +8,7 @@ import {
   Text,
   VStack,
 } from '@chakra-ui/react'
+import { useRouter } from 'next/router'
 import Header from '../src/components/organisms/Header/Header'
 import DetailCard from '../src/components/organisms/Todo/DetailCard'
 import BackButton from '../src/components/atoms/button/BackButton'
@@ -15,6 +16,9 @@ import CommentButton from '../src/components/atoms/button/CommentButton'
 import Comment from '../src/components/atoms/comment/Comment'
 
 function index() {
+  //Routerを定義
+  const router = useRouter()
+
   return (
     <>
       <Header />
@@ -33,7 +37,8 @@ function index() {
           </Flex>
         </Flex>
         <HStack spacing={1}>
-          <DetailCard />
+          {/* トップから渡ってきたquery情報をDerailCardに渡す */}
+          <DetailCard title={router.query.title} detail={router.query.detail} />
           <VStack pb="5" h="480" w="xl">
             <Comment />
           </VStack>

--- a/pages/ShowTodo.jsx
+++ b/pages/ShowTodo.jsx
@@ -38,7 +38,11 @@ function index() {
         </Flex>
         <HStack spacing={1}>
           {/* トップから渡ってきたquery情報をDerailCardに渡す */}
-          <DetailCard title={router.query.title} detail={router.query.detail} />
+          <DetailCard
+            title={router.query.title}
+            detail={router.query.detail}
+            created_day={router.query.created_day}
+          />
           <VStack pb="5" h="480" w="xl">
             <Comment />
           </VStack>

--- a/pages/ShowTodo.jsx
+++ b/pages/ShowTodo.jsx
@@ -35,7 +35,7 @@ function index() {
         <HStack spacing={1}>
           <DetailCard />
           <VStack pb="5" h="480" w="xl">
-          <Comment/>
+            <Comment />
           </VStack>
         </HStack>
         {/* ここにページネーションが入ります */}

--- a/src/components/atoms/TodoListChild.jsx
+++ b/src/components/atoms/TodoListChild.jsx
@@ -1,37 +1,54 @@
-import React from 'react';
-import {
-  Tbody,
-  Tr,
-  Td,
-  Button,
-  Select
-} from '@chakra-ui/react'
+import React from 'react'
+import { Tbody, Tr, Td, Button, Select } from '@chakra-ui/react'
 import { EditIcon, DeleteIcon } from '@chakra-ui/icons'
-
-
+import { useRecoilState } from 'recoil'
+import { todoState } from '../../hooks/TodoState'
+import { useRouter } from 'next/router'
 
 const TodoListChild = () => {
+  // TodoState.jsで定義したtodos,setTodosを呼び出し
+  const [todos, setTodos] = useRecoilState(todoState)
+
+  //ShowTodo遷移のためのRouterをセット
+  const router = useRouter()
+
   return (
     <Tbody>
-      <Tr>
-        <Td fontSize='16px' fontWeight="bold">Github上に静的サイトをホスティングする</Td>
-        <Td>
-        <Button rounded="full" bg="green.50" size="lg" fontSize='12px'>NOT STARTED</Button>
-        </Td>
-        <Td>
-          <Select borderColor="tomato" fontSize='16px'>
-            <option>High</option>
-            <option>Middle</option>
-            <option>Low</option>
-          </Select>
-        </Td>
-        <Td fontSize='14px'>2020-11-8 18:55</Td>
-        <Td fontSize='14px'>2020-11-8 18:55</Td>
-        <Td>
-        <EditIcon w={18} h={18} me={5} />
-        <DeleteIcon w={18} h={18}/>
-        </Td>
-      </Tr>
+      {todos.map((todo) => (
+        <Tr key={todo.id}>
+          <Td
+            fontSize="16px"
+            fontWeight="bold"
+            // ShowTodoへ遷移 & todoの中身を遷移先に渡す
+            onClick={() => {
+              router.push({
+                pathname: 'ShowTodo',
+                query: { title: todo.title, detail: todo.detail },
+              })
+            }}
+          >
+            {todo.title}
+          </Td>
+          <Td>
+            <Button rounded="full" bg="green.50" size="lg" fontSize="12px">
+              {todo.status}
+            </Button>
+          </Td>
+          <Td>
+            <Select borderColor="tomato" fontSize="16px">
+              <option>High</option>
+              <option>Middle</option>
+              <option>Low</option>
+            </Select>
+          </Td>
+          <Td fontSize="14px">{todo.created_day}</Td>
+          <Td fontSize="14px">2020-11-8 18:55</Td>
+          <Td>
+            <EditIcon w={18} h={18} me={5} />
+            <DeleteIcon w={18} h={18} />
+          </Td>
+        </Tr>
+      ))}
     </Tbody>
   )
 }

--- a/src/components/atoms/TodoListChild.jsx
+++ b/src/components/atoms/TodoListChild.jsx
@@ -23,7 +23,11 @@ const TodoListChild = () => {
             onClick={() => {
               router.push({
                 pathname: 'ShowTodo',
-                query: { title: todo.title, detail: todo.detail },
+                query: {
+                  title: todo.title,
+                  detail: todo.detail,
+                  created_day: todo.created_day,
+                },
               })
             }}
           >

--- a/src/components/atoms/TodoListChild.jsx
+++ b/src/components/atoms/TodoListChild.jsx
@@ -19,6 +19,7 @@ const TodoListChild = () => {
           <Td
             fontSize="16px"
             fontWeight="bold"
+            cursor="pointer"
             // ShowTodoへ遷移 & todoの中身を遷移先に渡す
             onClick={() => {
               router.push({

--- a/src/components/organisms/Todo/DetailCard.jsx
+++ b/src/components/organisms/Todo/DetailCard.jsx
@@ -9,6 +9,7 @@ import {
   Text,
   VStack,
 } from '@chakra-ui/react'
+import { useRecoilState } from 'recoil'
 import EditButton from '../../atoms/button/EditButton'
 
 export default function DetailCard() {
@@ -44,12 +45,12 @@ export default function DetailCard() {
             <EditButton />
           </Box>
           ‌ <Spacer />
-          <Stat>
+          <Stat whiteSpace="nowrap">
             <StatLabel fontSize="sm">Updated at</StatLabel>
             <StatNumber fontSize="md">2022-01-01 18:55</StatNumber>
           </Stat>
           <Spacer />
-          <Stat>
+          <Stat whiteSpace="nowrap">
             <StatLabel fontSize="sm">Created at</StatLabel>
             <StatNumber fontSize="md">2022-01-01 18:55</StatNumber>
           </Stat>

--- a/src/components/organisms/Todo/DetailCard.jsx
+++ b/src/components/organisms/Todo/DetailCard.jsx
@@ -9,10 +9,9 @@ import {
   Text,
   VStack,
 } from '@chakra-ui/react'
-import { useRecoilState } from 'recoil'
 import EditButton from '../../atoms/button/EditButton'
 
-export default function DetailCard() {
+export default function DetailCard({ title, detail }) {
   return (
     <VStack
       p={3}
@@ -28,14 +27,14 @@ export default function DetailCard() {
         <Heading as="h2" size="md" bg="green.300" px={3} my={1}>
           Title
         </Heading>
-        <Text fontSize="lg">Text</Text>
+        <Text fontSize="lg">{title}</Text>
       </Box>
       <Box w="full" h="full" minHeight={0}>
         <Heading as="h2" size="md" bg="green.300" px={3} my={1}>
           Detail
         </Heading>
         <Box h="100%" overflow="scroll">
-          <Text fontSize="lg">Text</Text>
+          <Text fontSize="lg">{detail}</Text>
         </Box>
       </Box>
       <Spacer />

--- a/src/components/organisms/Todo/DetailCard.jsx
+++ b/src/components/organisms/Todo/DetailCard.jsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react'
 import EditButton from '../../atoms/button/EditButton'
 
-export default function DetailCard({ title, detail }) {
+export default function DetailCard({ title, detail, created_day }) {
   return (
     <VStack
       p={3}
@@ -51,7 +51,7 @@ export default function DetailCard({ title, detail }) {
           <Spacer />
           <Stat whiteSpace="nowrap">
             <StatLabel fontSize="sm">Created at</StatLabel>
-            <StatNumber fontSize="md">2022-01-01 18:55</StatNumber>
+            <StatNumber fontSize="md">{created_day}</StatNumber>
           </Stat>
         </Flex>
       </Flex>

--- a/src/components/organisms/Todo/DetailCard.jsx
+++ b/src/components/organisms/Todo/DetailCard.jsx
@@ -10,8 +10,11 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import EditButton from '../../atoms/button/EditButton'
+import { useRouter } from 'next/router'
 
 export default function DetailCard({ title, detail, created_day }) {
+  const router = useRouter()
+
   return (
     <VStack
       p={3}
@@ -40,7 +43,7 @@ export default function DetailCard({ title, detail, created_day }) {
       <Spacer />
       <Flex pt={3} w="full">
         <Flex justifyContent="flex-end" w="full" p={4}>
-          <Box>
+          <Box onClick={() => router.push('/EditTodo')}>
             <EditButton />
           </Box>
           ‌ <Spacer />


### PR DESCRIPTION
## IssueのURL
close #72

## 対応内容・対応背景・妥協点
・todo一覧のタイトルと詳細をShowTodoで見れるようにしました。
（#7【 機能 】タスクをクリックで詳細画面に遷移Issueも併用で実装しています...）


## やったこと
・routerを使用してtodo一覧のタイトルからShowTodoへの遷移機能を実装
・その際にクリックしたtodoのタイトル、詳細、created dayをqueryとしてShowtodoに引き継ぎ


## やってないこと・できていないこと
 updated dayは現状ShowTodoに引き継いでいません

