### PR TITLE
#76-MIHO ページネーターのページ数の変化を実装

### DIFF
--- a/pages/Newtodo.jsx
+++ b/pages/Newtodo.jsx
@@ -20,10 +20,12 @@ export default function NewTodo() {
 
   // Now.jsで定義したcurerntTimeを呼び出し
   const { currentTime } = getTime()
-
   const [title, setTitle] = useState('')
   const [detail, setDetail] = useState('')
   const [priority, setPriority] = useState('')
+
+  // エラーの表示と非表示を管理するステートを定義
+  const [formErrors, setFormErrors] = useState({})
 
   // 新しいTodoのidを定義
   const id =
@@ -32,21 +34,40 @@ export default function NewTodo() {
     // 乱数を取得し文字列型に変更し文字列連結
     Math.floor(Math.random() * 10).toString()
 
-  // Todosに新しいTodoを追加
+  // タイトル欄、詳細欄、ラジオボタンの下に表示させるエラー文を定義
+  const validate = (title, detail, priority) => {
+    const errors = {}
+    if (!title) {
+      errors.title = 'Title is required!'
+    }
+    if (!detail) {
+      errors.detail = 'Detail is required!'
+    }
+    if (!priority) {
+      errors.priority = 'Priority is required!'
+    }
+    return errors
+  }
   const onSubmit = () => {
-    const newTodos = [
-      {
-        id,
-        title,
-        detail,
-        priority,
-        status: 'not_started',
-        created_day: currentTime,
-      },
-      ...todos,
-    ]
-    setTodos(newTodos)
-    Router.push('/')
+    if (!title || !detail || !priority) {
+      // 空欄が一か所でもあれば、validate関数で定義したエラー文を表示し、else以降の処理が行われないようにする
+      setFormErrors(validate(title, detail, priority))
+    } else {
+      //欄が全て埋まっていたらTodosに新しいTodoを追加し、ページ遷移する
+      const newTodos = [
+        {
+          id,
+          title,
+          detail,
+          priority,
+          status: 'not_started',
+          created_day: currentTime,
+        },
+        ...todos,
+      ]
+      setTodos(newTodos)
+      Router.push('/')
+    }
   }
 
   return (
@@ -62,9 +83,11 @@ export default function NewTodo() {
             <BackButton />
           </Flex>
           <Title title={title} setTitle={setTitle} />
+          <Text color="red">{formErrors.title}</Text>
           <DetailTextarea detail={detail} setDetail={setDetail} />
+          <Text color="red">{formErrors.detail}</Text>
           <RadioPriority setPriority={setPriority} />
-
+          <Text color="red">{formErrors.priority}</Text>
           <Flex>
             <HStack spacing="24px" pos="absolute" right="20">
               <DraftButton />

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,5 @@
+import React,{useState} from "react"
+import { useRecoilValue } from 'recoil'
 import { Box, Container, Flex, Heading, HStack, Spacer } from '@chakra-ui/react'
 import MainButtons from '../src/components/molecules/MainButtons'
 import Header from '../src/components/organisms/Header/Header'
@@ -6,8 +8,22 @@ import SearchStatus from '../src/components/atoms/search/SearchStatus'
 import { SearchPriority } from '../src/components/atoms/search/SearchPriority'
 import TodoTable from '../src/components/organisms/Todo/TodoTable'
 import { ResetButton } from '../src/components/atoms/button/ResetButton'
+import Pagination from "../src/components/molecules/Pagination";
+import { todoState } from '../src/hooks/TodoState'
 
 export default function Home() {
+  // todosの読み込み機能だけ利用
+  const todos = useRecoilValue(todoState)
+
+  // 1ページに表示するtodoItemの数を設定
+  const itemLimit = 5;
+
+  // pagenationのページ数を監視するstateを定義
+  const [pagesQuantity, setPagesQuantity] = useState(0);
+
+   // 現在表示中のページを監視するstateを定義
+   const [curPage, setCurPage] = useState(1);
+
   return (
     <>
       <Header />
@@ -34,6 +50,17 @@ export default function Home() {
           </Box>
         </Flex>
         <TodoTable />
+        {/* todosが0～表示限度数の間、ページネーターは非表示 */}
+        {todos.length > itemLimit && 
+          <Flex justifyContent="center">
+            <Pagination
+              itemLimit={itemLimit}
+              setCurPage={setCurPage}
+              pagesQuantity={pagesQuantity}
+              setPagesQuantity={setPagesQuantity}
+            />
+          </Flex>
+        }
       </Container>
     </>
   )

--- a/src/components/molecules/Pagination.jsx
+++ b/src/components/molecules/Pagination.jsx
@@ -1,10 +1,35 @@
-import { ChakraProvider, HStack } from '@chakra-ui/react'
+import React, { useEffect } from 'react'
+import { useRecoilValue } from 'recoil'
+import { HStack } from '@chakra-ui/react'
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons'
+import {
+  Paginator,
+  Previous,
+  Next,
+  PageGroup,
+  generatePages,
+} from 'chakra-paginator'
+import { todoState } from '../../hooks/TodoState'
 
-import { Paginator, Previous, Next, PageGroup } from 'chakra-paginator'
+const Pagination = (props) => {
+  // TodoState.jsで定義したtodos,setTodosを呼び出し
+  const todos = useRecoilValue(todoState)
 
-const Pagination = () => {
-  const pagesQuantity = 6
+  // 親コンポーネントから以下をpropsとして受け取る
+  const { setCurPage, itemLimit, pagesQuantity, setPagesQuantity } = props
+
+  // ページネーターでページが選択される度にstate:curPageが更新される
+  const handlePageChange = (page) => {
+    setCurPage(page)
+  }
+
+  // todosの要素数が変化するたびに、ページネーターのページ総数を変更
+  useEffect(() => {
+    // ページネーターのページ総数は、todoリストのオブジェクト数と1ページあたりの表示数から算出
+    const pagesTotal = Math.ceil(todos.length / itemLimit)
+    // 上で算出したページ総数をpagesQuantityに格納する
+    setPagesQuantity(pagesTotal)
+  }, [todos.length, itemLimit])
 
   /* 通常　buttonスタイル  */
   const normalStyles = {
@@ -34,12 +59,17 @@ const Pagination = () => {
       activeStyles={activeStyles}
       normalStyles={normalStyles}
       pagesQuantity={pagesQuantity}
+      onPageChange={handlePageChange}
     >
       <HStack spacing="20px" p={4}>
         <Previous w={8} h={8} bg="White" border="1px solid Black">
           <ChevronLeftIcon color="gray.400" w={5} h={5} />
         </Previous>
-        <PageGroup isInline align="center" spacing="10px" />
+        <PageGroup isInline align="center" spacing="10px">
+          {generatePages(pagesQuantity)?.map((page) => (
+            <Page key={`paginator_page_${page}`} page={page} />
+          ))}
+        </PageGroup>
         <Next w={8} h={8} bg="White" border="1px solid Black">
           <ChevronRightIcon color="gray.400" w={5} h={5} />
         </Next>

--- a/src/components/molecules/Pagination.jsx
+++ b/src/components/molecules/Pagination.jsx
@@ -29,7 +29,7 @@ const Pagination = (props) => {
     const pagesTotal = Math.ceil(todos.length / itemLimit)
     // 上で算出したページ総数をpagesQuantityに格納する
     setPagesQuantity(pagesTotal)
-  }, [todos.length, itemLimit])
+  }, [todos.length])
 
   /* 通常　buttonスタイル  */
   const normalStyles = {


### PR DESCRIPTION
## IssueのURL
#76 

## 対応内容・対応背景・妥協点
todoリストのオブジェクト数に応じて、ページネーターのページ数が増減するように実装

## やったこと
-index.jsにpagenatorを取り込み、UI調整
-1ページあたりのtodo表示限度数を定義し、todoの個数の変化に応じてページネーターに表示されるページ番号(1,2,3...)が変化するように実装
-todoが０～1ページ目の表示限度数のとき、ページネーター自体を非表示にする

## UI before / after
![ページネーション](https://user-images.githubusercontent.com/93969412/153004652-958e923b-83d3-49b5-8a04-7266cdfdcacb.png)

