### PR TITLE
#70 Yuri NewTodoとTodo一覧のpriority連動と永続化

### DIFF
--- a/pages/Newtodo.jsx
+++ b/pages/Newtodo.jsx
@@ -14,23 +14,26 @@ import Header from '../src/components/organisms/Header/Header'
 import { todoState } from '../src/hooks/TodoState'
 import { getTime } from '../src/utils/Now'
 
+
 export default function NewTodo() {
-  // TodoState.jsで定義したtosos,setTodosを呼び出し
-  const [todos, setTodos] = useRecoilState(todoState)
 
-  // Now.jsで定義したcurerntTimeを呼び出し
-  const { currentTime } = getTime()
+    // TodoState.jsで定義したtosos,setTodosを呼び出し
+    const [todos, setTodos] = useRecoilState(todoState)
 
-  const [title, setTitle] = useState('')
-  const [detail, setDetail] = useState('')
-  const [priority, setPriority] = useState('')
+    // Now.jsで定義したcurerntTimeを呼び出し
+    const { currentTime } = getTime()
 
-  // 新しいTodoのidを定義
-  const id =
-    // ミリ単位での日付を取得し文字列型に変更
-    new Date().getTime().toString() +
-    // 乱数を取得し文字列型に変更し文字列連結
-    Math.floor(Math.random() * 10).toString()
+    const [title, setTitle] = useState('')
+    const [detail, setDetail] = useState('')
+    const [priority, setPriority] = useState('')
+
+    // 新しいTodoのidを定義
+    const id =
+      // ミリ単位での日付を取得し文字列型に変更
+      new Date().getTime().toString() +
+      // 乱数を取得し文字列型に変更し文字列連結
+      Math.floor(Math.random() * 10).toString()
+
 
   // Todosに新しいTodoを追加
   const onSubmit = () => {
@@ -63,7 +66,7 @@ export default function NewTodo() {
           </Flex>
           <Title title={title} setTitle={setTitle} />
           <DetailTextarea detail={detail} setDetail={setDetail} />
-          <RadioPriority setPriority={setPriority} />
+          <RadioPriority priority={priority} setPriority={setPriority} />
 
           <Flex>
             <HStack spacing="24px" pos="absolute" right="20">

--- a/pages/Newtodo.jsx
+++ b/pages/Newtodo.jsx
@@ -14,7 +14,6 @@ import Header from '../src/components/organisms/Header/Header'
 import { todoState } from '../src/hooks/TodoState'
 import { getTime } from '../src/utils/Now'
 
-
 export default function NewTodo() {
 
     // TodoState.jsで定義したtosos,setTodosを呼び出し

--- a/src/components/atoms/TodoListChild.jsx
+++ b/src/components/atoms/TodoListChild.jsx
@@ -4,7 +4,6 @@ import { EditIcon, DeleteIcon } from '@chakra-ui/icons'
 import { useRecoilState } from 'recoil'
 import { todoState } from '../../hooks/TodoState'
 import { todoStatus } from '../atoms/status/todoStatus'
-
 import TodoPriority from './status/TodoPriority'
 
 const TodoListChild = () => {

--- a/src/components/atoms/TodoListChild.jsx
+++ b/src/components/atoms/TodoListChild.jsx
@@ -1,14 +1,16 @@
 import React from 'react'
-import { Tbody, Tr, Td, Button, Select } from '@chakra-ui/react'
+import { Tbody, Tr, Td, Button } from '@chakra-ui/react'
 import { EditIcon, DeleteIcon } from '@chakra-ui/icons'
 import { useRecoilState } from 'recoil'
 import { todoState } from '../../hooks/TodoState'
 import { todoStatus } from '../atoms/status/todoStatus'
-import { todoPriority } from '../atoms/status/todoPriority'
+
+import TodoPriority from './status/TodoPriority'
 
 const TodoListChild = () => {
   // TodoState.jsで定義したtodos,setTodosを呼び出し
   const [todos, setTodos] = useRecoilState(todoState)
+
   return (
     <Tbody>
       {todos.map((todo) => (
@@ -18,17 +20,12 @@ const TodoListChild = () => {
           </Td>
           <Td>
             <todoStatus />
-            {/* <Button rounded="full" bg="green.50" size="lg" fontSize="12px">
+            <Button rounded="full" bg="green.50" size="lg" fontSize="12px">
               {todo.status}
-            </Button> */}
+            </Button>
           </Td>
           <Td>
-            <todoPriority />
-            {/* <Select borderColor="tomato" fontSize="16px">
-              <option>High</option>
-              <option>Middle</option>
-              <option>Low</option>
-            </Select> */}
+            <TodoPriority id={todo.id} priority={todo.priority}/>
           </Td>
           <Td fontSize="14px">{todo.created_day}</Td>
           <Td fontSize="14px">2020-11-8 18:55</Td>
@@ -43,3 +40,4 @@ const TodoListChild = () => {
 }
 
 export default TodoListChild
+

--- a/src/components/atoms/status/todoPriority.jsx
+++ b/src/components/atoms/status/todoPriority.jsx
@@ -11,7 +11,7 @@ const TodoPriority = (props) => {
       set(todoState, (todoOld) => todoOld.map(
         todoOld => todoOld.id === id
         ? { ...todoOld, priority }
-        : t))
+        : todoOld))
     }
   )
   const handleChange = useCallback(

--- a/src/components/atoms/status/todoPriority.jsx
+++ b/src/components/atoms/status/todoPriority.jsx
@@ -1,0 +1,52 @@
+import React, { useCallback } from 'react'
+import { Select } from '@chakra-ui/react'
+import { useRecoilCallback } from 'recoil'
+import { todoState } from '../../../hooks/TodoState'
+
+const TodoPriority = (props) => {
+  const { id, priority } = props
+  //atomにセレクトボックスで選んだ時の値をsetする
+  const updateTodo = useRecoilCallback(({ set }) =>
+    (id, priority) => {
+      set(todoState, (todoOld) => todoOld.map(
+        todoOld => todoOld.id === id
+        ? { ...todoOld, priority }
+        : t))
+    }
+  )
+  const handleChange = useCallback(
+    (e) => updateTodo(
+      id, e.target.value
+      ),
+      [priority])
+
+  return (
+    <>
+      <Select
+        value={priority}
+        id="topSelectBox"
+        onChange={handleChange}
+        borderColor="tomato"
+        fontSize="16px">
+        <option
+          value="High"
+        >
+          High
+        </option>
+        <option
+          value="Middle"
+        >
+          Middle
+        </option>
+        <option
+          value="Low"
+        >
+          Low
+        </option>
+      </Select>
+    </>
+  )
+}
+
+export default TodoPriority
+

--- a/src/components/organisms/Todo/TodoTable.jsx
+++ b/src/components/organisms/Todo/TodoTable.jsx
@@ -1,7 +1,7 @@
 import { Table, Tbody, Thead, Th, Tr, Td } from '@chakra-ui/react'
 import TodoListChild from '../../atoms/TodoListChild'
 
-export default function TodosTable() {
+export default function TodoTable() {
   return (
     <Table size="md">
       <Thead bg="green.300">

--- a/src/components/organisms/Todo/TodoTable.jsx
+++ b/src/components/organisms/Todo/TodoTable.jsx
@@ -3,6 +3,7 @@ import TodoListChild from '../../atoms/TodoListChild'
 
 export default function TodoTable() {
   return (
+
     <Table size="md">
       <Thead bg="green.300">
         <Tr>

--- a/src/hooks/TodoState.js
+++ b/src/hooks/TodoState.js
@@ -7,6 +7,8 @@ const { persistAtom } = recoilPersist()
 export const todoState = atom({
   key: 'todos',
   default: [],
+  storage: typeof window === 'undefined' ? undefined : window.sessionStorage,
+
   // 状態を永続化
   effects_UNSTABLE: [persistAtom],
 })


### PR DESCRIPTION
## IssueのURL

#70 

## 対応内容・対応背景・妥協点
ブランチ名が[#70-status-btn-YURI]となってますが、やっていることはpriorityに関する作業です。ブランチ名を間違えました。

- todoStateのatomを使ったデータ永続化処理
（Todo一覧ページのセレクトボックスの値が、リロードされても変更を保持できるようにする　例: Middle選択　→ リロード　→ Middle選択が保持）
- NewTodoページpriorityの値がTodo一覧ページのセレクトボックスに渡されるようにする。
（例:  NewTodoラジオボタンでLow選択　→ Todo一覧ページでもLowが選択）
- todoStateのatom内にNext.jsのSSR re-renderingの影響で永続化ができないことの対策のために、デフォルトのlocalstorageではなく、storageオプションからsession storageを指定するように記述

## UI before / after

<a href="https://gyazo.com/7ec92d3f796622c92a19a6534e8bb068"><img src="https://i.gyazo.com/7ec92d3f796622c92a19a6534e8bb068.gif" alt="Image from Gyazo" width="1000"/></a>


### 静止画（NewTodo）
<a href="https://gyazo.com/1ea8361f5823bdf0e9855019e55d04f1"><img src="https://i.gyazo.com/1ea8361f5823bdf0e9855019e55d04f1.png" alt="Image from Gyazo" width="1226"/></a>


### 静止画（TodoList）
<a href="https://gyazo.com/3cefc1b935eb4af8692017ab3e397a82"><img src="https://i.gyazo.com/3cefc1b935eb4af8692017ab3e397a82.png" alt="Image from Gyazo" width="1264"/></a>


### TodoListでリロードした時のpriorityの永続化
<a href="https://gyazo.com/6dfe4eaaf737ab67b1ef580e857d1f1f"><img src="https://i.gyazo.com/6dfe4eaaf737ab67b1ef580e857d1f1f.gif" alt="Image from Gyazo" width="1000"/></a>