### PR TITLE
#115 【本番環境】todoアプリのデプロイ

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,17 +1,22 @@
+# GitHub リポジトリの [Actions] タブに表示されるワークフローの名前を任意で指定
 name: GitHub Pages
 
-# mainブランチにプッシュしたときにjobsに記述した操作を行う
+# ここではワークフローを起動させる特定のイベントを指定する
+# mainブランチにプッシュしたときにjobsに記述した操作（＝デプロイ）を行う
 on:
   push:
     branches:
       - main
 
+# 本GitHub Pagesワークフローで実行されるjobを全て記載
 jobs:
   deploy:
-    # ubuntu OSを仮想マシン上に用意する
+    # ここではワークフローを実行するランナー（仮想マシン上で動く）を指定する
     runs-on: ubuntu-20.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
+
+    # ワークフローは以下の順に実行される
     steps:
       - uses: actions/checkout@v2
 
@@ -19,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.17.0'
+          node-version: '14'
 
       # yarn addの際にキャッシュを使うよう設定
       - name: Cache dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,62 @@
+name: GitHub Pages
+
+# mainブランチにプッシュしたときにjobsに記述した操作を行う
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    # ubuntu OSを仮想マシン上に用意する
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      # Node.js環境のセットアップを行う
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.17.0'
+
+      # yarn addの際にキャッシュを使うよう設定
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      # yarn.lockに基づき依存パッケージをインストールする
+      - name: Install
+        run: yarn install --frozen-lockfile
+
+      # Next.jsアプリをビルドする
+      # プロジェクトルート直下に.nextディレクトリができる
+      - name: Build
+        run: yarn　build
+
+      # 静的なHTMLとしてNext.jsアプリを生成する
+      # プロジェクトルート直下にoutディレクトリができる
+      #そのなかに、HTMLファイル群と、それらが読み込むJSファイル群を収めた_nextディレクトリがある
+      - name: Export
+        run: yarn export
+
+      # しかしGitHub Pagesの仕様として_から始まるディレクトリが見えず404となる
+      # つまりHTMLからJSを読み込めない
+      # これを回避するために.nojekyllファイルをoutディレクトリに作る
+      - name: Add Nojekyll
+        run: touch ./out/.nojekyll
+
+      # gh-pagesブランチを自動的に作成する
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          # トークンは自動的に生成される
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # gh-pagesブランチ作成の際にoutディレクトリの中身をプッシュする
+          publish_dir: ./out

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "export": "next export",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore",
     "stylelint": "stylelint \"**/*.scss\""
   },

--- a/src/components/organisms/Todo/TodoTable.jsx
+++ b/src/components/organisms/Todo/TodoTable.jsx
@@ -5,7 +5,6 @@ import { todoState } from '../../../hooks/TodoState'
 import TodoListChild from '../../atoms/TodoListChild'
 
 export default function TodosTable({ curPage, itemLimit }) {
-
   // TodoState.jsで定義したtodos,setTodosを呼び出し
   const [todos, setTodos] = useRecoilState(todoState)
 
@@ -18,7 +17,7 @@ export default function TodosTable({ curPage, itemLimit }) {
     setCurItems(todos.slice(offset, offset + itemLimit))
   }, [curPage, todos.length])
 
-  console.log(itemLimit);
+  console.log(itemLimit)
 
   return (
     <Table size="md">
@@ -31,19 +30,19 @@ export default function TodosTable({ curPage, itemLimit }) {
           <Th>Update</Th>
           <Th>Action</Th>
         </Tr>
-      </Thead
+      </Thead>
       <Tbody>
         {
           // useRecoilValueで呼び出したtodos内のtodoを順に取り出し処理を行う。
           curItems.map((todo, index) => {
-            return(
-            <TodoListChild
-            id={todo.id}
-            status={todo.status}
-            created_day={todo.created_day}
-            updated_day={todo.updated_day}
-            title={todo.title}
-            />
+            return (
+              <TodoListChild
+                id={todo.id}
+                status={todo.status}
+                created_day={todo.created_day}
+                updated_day={todo.updated_day}
+                title={todo.title}
+              />
             )
           })
         }


### PR DESCRIPTION
## IssueのURL
closes #115 

## 対応内容・対応背景・妥協点
- GitHub Actions を用いて、自動でデプロイが行われるようにするための準備

## やったこと
- packege.jsonにexportを加筆
- yarn run buildと、yarn run exportコマンドを実行し、outディレクトを生成
- .github/workflows/gh-pages.ymlを作成

## やってないこと・できていないこと
- デプロイ（ 通常、.github/workflows/gh-pages.ymを作成した後、リモートのmainにpushすると自動でGitHub ActionsによるNextのビルドとGitHub Pagesへのデプロイが始まります。しかし、本開発プロジェクトでは、ローカルから直接リモートのmainブランチへのpushができない設定になっています。そのため、本プルリクではその前段階までをレビューしていただきたいです。）

## GitHub Actionsを利用したデプロイの流れ
1. ローカルで特別なファイルを準備して、GitHubへPush （今回のプルリクはここまで）
2. するとGitHub Actions が作成したファイルの記述に沿ってビルドを行い、ビルド後のファイルを main リポジトリへアップロードし、GitHub Pages で公開してくれる

## なぜGitHub Pagesでのデプロイか
1. Next.jsアプリのデプロイでよく選ばれるVercelはアカウントを作成しないと使えず、今回のようなデモチーム開発には向かないため（だれのアカウント利用する???となる）
2. 今回のプロジェクトでは、静的ホスティングで十分
https://zenn.dev/yohei_watanabe/articles/0d30bcf579f939

## 参考
### Quittaの記事（基本的にはこれらに則って実装）
https://qiita.com/manten120/items/87e9e822800403904dc8
https://qiita.com/peaceiris/items/9c569125b25fc090c515
### GitHub Actions を説明したgitページの、Examples段落のReact and Nextセクション
https://github.com/peaceiris/actions-gh-pages
### GitHub Actions とは (.github/workflows/gh-pages.ymlの内容の説明)
https://docs.github.com/ja/actions/learn-github-actions/understanding-github-actions