### PR TITLE
#70 WIP Yuri Priority 一覧ページでstateの変更が保持されるようリファクタ

### DIFF
--- a/src/components/atoms/status/todoPriority.jsx
+++ b/src/components/atoms/status/todoPriority.jsx
@@ -1,25 +1,18 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 import { Select } from '@chakra-ui/react'
-import { useRecoilCallback } from 'recoil'
 import { todoState } from '../../../hooks/TodoState'
 
 const TodoPriority = (props) => {
   const { id, priority } = props
-  //atomにセレクトボックスで選んだ時の値をsetする
-  const updateTodo = useRecoilCallback(({ set }) =>
-    (id, priority) => {
-      set(todoState, (todoOld) => todoOld.map(
-        todoOld => todoOld.id === id
-        ? { ...todoOld, priority }
-        : todoOld))
-    }
+
+  const [todos, setTodos] = useRecoilState(todoState)
+
+  const handleChange = (e) => {
+  const newTodos = [...todos].map((todo) =>
+  todo.id === id ? { ...todo, priority: e.target.value } : todo
   )
-  const handleChange = useCallback(
-    (e) => updateTodo(
-      id, e.target.value
-      ),
-      [priority])
-      // console.log(priority);
+  setTodos(() => newTodos)
+  }
 
   return (
     <>
@@ -50,4 +43,3 @@ const TodoPriority = (props) => {
 }
 
 export default TodoPriority
-

--- a/src/components/organisms/Todo/TodoTable.jsx
+++ b/src/components/organisms/Todo/TodoTable.jsx
@@ -12,14 +12,12 @@ export default function TodosTable({ curPage, itemLimit }) {
   const [curItems, setCurItems] = useState([])
 
   // itemLimit数に応じた新しいtodo配列を生成し、curItemsにセット
+  //一覧ページでpriorityとstatusのstateを監視するため第二引数をtodos.length　→ todosにした
+
   useEffect(() => {
     const offset = curPage * itemLimit
     setCurItems(todos.slice(offset, offset + itemLimit))
-  }, [curPage, todos.length])
-
-  // console.log(todos.priority);
-
-  // console.log(itemLimit)
+    }, [curPage, todos])
 
   return (
     <Table size="md">


### PR DESCRIPTION
## IssueのURL

#70

## やったこと
みほさんのレビューに従い、下記をリファクタした。
### TodoPriority.jsx
- useCallbackやuseRecoilCallbackを取り除いてuseRecoilStateでatomからstateを取り出す。
idを使って一覧ページの値を新しいstateの値として保持。

### TodoTable.jsx
- useEffectの第二引数にtodos.lengthが入っていたが、これだと一覧のpriorityはリロード後に値が変更されるようになってしまうため、todosに変更した